### PR TITLE
fix attributes that consist of only a key instead of key=value

### DIFF
--- a/src/class-shortcode-tree.php
+++ b/src/class-shortcode-tree.php
@@ -164,6 +164,11 @@ class Shortcode {
 		
 		if (count ( $this->atts ))
 			$out .= ' ' . implode ( ' ', array_map ( function ($key) use($atts) {
+				$value = $atts[$key];
+				if (is_int( $key )) {
+					return $value;
+				} 
+
 				return $key . '="' . $atts [$key] . '"';
 			}, array_keys ( $this->atts ) ) );
 		


### PR DESCRIPTION
This fixes attributes that do simply consist of a key instead of a key-value pair.
```
[av_one_third first min_height='']
```
would turn into
```
[av_one_third 0=first min_height='']
```